### PR TITLE
Ignore dev version

### DIFF
--- a/pkg/run.go
+++ b/pkg/run.go
@@ -38,7 +38,7 @@ func Run(c *cli.Context) (err error) {
 	latestVersion, err := utils.FetchLatestVersion()
 
 	// check latest version
-	if err == nil && cliVersion != latestVersion {
+	if err == nil && cliVersion != latestVersion && c.App.Version != "dev" {
 		log.Logger.Warnf("A new version %s is now available! You have %s.", latestVersion, cliVersion)
 	}
 


### PR DESCRIPTION
Ignore the following warning
```
2019-06-07T13:23:07.747+0900    WARN    A new version v0.0.15 is now available! You have vdev.
```